### PR TITLE
feat(union-type): adds support for OneOf and AnyOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ gem 'apimatic_core_interfaces'
 ```
 
 ## Interfaces
-| Name                                                                                 | Description                                                                               |
-|--------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| [`HttpClient`](lib/apimatic-core-interfaces/client/http_client.rb)                   | To save both Request and Response after the completion of response                        |
-| [`ResponseFactory`](lib/apimatic-core-interfaces/factories/response_factory.rb)      | To convert the client-adapter response into a custom HTTP response                        |
-| [`Authentication`](lib/apimatic-core-interfaces/types/authentication.rb)             | To setup methods for the validation and application of the required authentication scheme |
-| [`UnionType`](lib/apimatic-core-interfaces/types/union_type.rb)                      | To setup methods for the validation and deserialization of OneOf/AnyOf union types   |
-| [`ClientConfiguration`](lib/apimatic-core-interfaces/client/client_configuration.rb) | To setup the http client configurations including retries, timeouts and connections etc. |
+| Name                                                                                 | Description                                                                                       |
+|--------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| [`HttpClient`](lib/apimatic-core-interfaces/client/http_client.rb)                   | To save both Request and Response after the completion of response                                |
+| [`ResponseFactory`](lib/apimatic-core-interfaces/factories/response_factory.rb)      | To convert the client-adapter response into a custom HTTP response                                |
+| [`Authentication`](lib/apimatic-core-interfaces/types/authentication.rb)             | To setup methods for the validation and application of the required authentication scheme         |
+| [`UnionType`](lib/apimatic-core-interfaces/types/union_type.rb)                      | To setup methods for the validation, serialization and deserialization of OneOf/AnyOf union types |
+| [`ClientConfiguration`](lib/apimatic-core-interfaces/client/client_configuration.rb) | To setup the http client configurations including retries, timeouts and connections etc.          |
 
 
 ## Enumerations

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ gem 'apimatic_core_interfaces'
 ```
 
 ## Interfaces
-| Name                                                                                 | Description                                                                                |
-|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| [`HttpClient`](lib/apimatic-core-interfaces/client/http_client.rb)                   | To save both Request and Response after the completion of response                         |
-| [`ResponseFactory`](lib/apimatic-core-interfaces/factories/response_factory.rb)      | To convert the client-adapter response into a custom HTTP response                         |
-| [`Authentication`](lib/apimatic-core-interfaces/types/authentication.rb)             | To setup methods for the validation and application of the required authentication scheme  |
-| [`ClientConfiguration`](lib/apimatic-core-interfaces/client/client_configuration.rb) | To setup the http client configurations including retries, timeouts and connections etc.  |
+| Name                                                                                 | Description                                                                               |
+|--------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| [`HttpClient`](lib/apimatic-core-interfaces/client/http_client.rb)                   | To save both Request and Response after the completion of response                        |
+| [`ResponseFactory`](lib/apimatic-core-interfaces/factories/response_factory.rb)      | To convert the client-adapter response into a custom HTTP response                        |
+| [`Authentication`](lib/apimatic-core-interfaces/types/authentication.rb)             | To setup methods for the validation and application of the required authentication scheme |
+| [`UnionType`](lib/apimatic-core-interfaces/types/union_type.rb)                      | To setup methods for the validation and deserialization of OneOf/AnyOf union types   |
+| [`ClientConfiguration`](lib/apimatic-core-interfaces/client/client_configuration.rb) | To setup the http client configurations including retries, timeouts and connections etc. |
 
 
 ## Enumerations

--- a/apimatic_core_interfaces.gemspec
+++ b/apimatic_core_interfaces.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core_interfaces'
-  s.version = '0.1.2'
+  s.version = '0.1.3'
   s.summary = 'An abstract layer of the functionalities provided by apimatic-core, faraday-client-adapter and '\
               'APIMatic SDKs.'
   s.description = 'This project contains the abstract layer for APIMatic\'s core library.'\

--- a/apimatic_core_interfaces.gemspec
+++ b/apimatic_core_interfaces.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core_interfaces'
-  s.version = '0.1.3'
+  s.version = '0.2.0'
   s.summary = 'An abstract layer of the functionalities provided by apimatic-core, faraday-client-adapter and '\
               'APIMatic SDKs.'
   s.description = 'This project contains the abstract layer for APIMatic\'s core library.'\

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -14,7 +14,7 @@ module CoreLibrary
 
     attr_accessor :is_valid, :error_messages
     attr_reader :union_type_context, :union_types
-    
+
     # Initializes a new instance of UnionType.
     # @param union_types [Array<Class>] An array of allowed types for the union.
     # @param union_type_context [Object] The context of the union type.

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -38,7 +38,7 @@ module CoreLibrary
     # @param value [Object] The value to deserialize.
     # @param should_symbolize [Boolean] Indicates whether the deserialized value should be symbolized.
     # @raise [NotImplementedError] If the method is not implemented in a subclass.
-    def deserialize(value, should_symbolize = false)
+    def deserialize(value, should_symbolize: false)
       raise NotImplementedError, 'This method needs
           to be implemented in a child class.'
     end

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -1,8 +1,17 @@
 module CoreLibrary
-  # Represents a union type that can validate and deserialize values based on a set of allowed types.
 
+  # Represents a union type that can validate and deserialize values based on a set of allowed types.
   class UnionType
-    NATIVE_TYPES = [Integer, String, Float, TrueClass, FalseClass]
+    # NATIVE_TYPES represents the list of native types in Ruby.
+    # These types are commonly used and built-in to the Ruby language.
+    # The constant contains the following types:
+    # - Integer: Represents whole numbers without a decimal point.
+    # - String: Represents a sequence of characters.
+    # - Float: Represents floating-point numbers with a decimal point.
+    # - TrueClass: Represents the boolean value `true`.
+    # - FalseClass: Represents the boolean value `false`.
+    # This constant is used within the UnionType class to define the allowed native types.
+    NATIVE_TYPES = [Integer, String, Float, TrueClass, FalseClass].freeze
 
     # Initializes a new instance of UnionType.
     # @param union_types [Array<Class>] An array of allowed types for the union.

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -12,6 +12,8 @@ module CoreLibrary
     # This constant is used within the UnionType class to define the allowed native types.
     NATIVE_TYPES = [Integer, String, Float, TrueClass, FalseClass].freeze
 
+    attr_accessor :is_valid, :error_messages
+    attr_reader :union_type_context, :union_types
     # Initializes a new instance of UnionType.
     # @param union_types [Array<Class>] An array of allowed types for the union.
     # @param union_type_context [Object] The context of the union type.
@@ -38,12 +40,6 @@ module CoreLibrary
     def deserialize(value)
       raise NotImplementedError, 'This method needs
           to be implemented in a child class.'
-    end
-
-    # Gets the context of the union type.
-    # @return [Object] The context of the union type.
-    def get_context
-      @union_type_context
     end
   end
 end

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -14,6 +14,7 @@ module CoreLibrary
 
     attr_accessor :is_valid, :error_messages
     attr_reader :union_type_context, :union_types
+    
     # Initializes a new instance of UnionType.
     # @param union_types [Array<Class>] An array of allowed types for the union.
     # @param union_type_context [Object] The context of the union type.

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -36,8 +36,9 @@ module CoreLibrary
     # Deserializes a value based on the union type.
     # This method should be implemented by subclasses.
     # @param value [Object] The value to deserialize.
+    # @param should_symbolize [Boolean] Indicates whether the deserialized value should be symbolized.
     # @raise [NotImplementedError] If the method is not implemented in a subclass.
-    def deserialize(value)
+    def deserialize(value, should_symbolize = false)
       raise NotImplementedError, 'This method needs
           to be implemented in a child class.'
     end

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -1,5 +1,5 @@
 module CoreLibrary
-  # Represents a union type that can validate and deserialize values based on a set of allowed types.
+  # Represents a union type that can validate, serialize and deserialize values based on a set of allowed types.
   class UnionType
     # NATIVE_TYPES represents the list of native types in Ruby.
     # These types are commonly used and built-in to the Ruby language.

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -1,0 +1,41 @@
+module CoreLibrary
+  # Represents a union type that can validate and deserialize values based on a set of allowed types.
+
+  class UnionType
+    NATIVE_TYPES = [Integer, String, Float, TrueClass, FalseClass]
+
+    # Initializes a new instance of UnionType.
+    # @param union_types [Array<Class>] An array of allowed types for the union.
+    # @param union_type_context [Object] The context of the union type.
+    def initialize(union_types, union_type_context)
+      @union_types = union_types
+      @union_type_context = union_type_context
+      @is_valid = false
+      @error_messages = Set.new
+    end
+
+    # Validates a value against the union type.
+    # This method should be implemented by subclasses.
+    # @param value [Object] The value to validate.
+    # @raise [NotImplementedError] If the method is not implemented in a subclass.
+    def validate(value)
+      raise NotImplementedError, 'This method needs
+          to be implemented in a child class.'
+    end
+
+    # Deserializes a value based on the union type.
+    # This method should be implemented by subclasses.
+    # @param value [Object] The value to deserialize.
+    # @raise [NotImplementedError] If the method is not implemented in a subclass.
+    def deserialize(value)
+      raise NotImplementedError, 'This method needs
+          to be implemented in a child class.'
+    end
+
+    # Gets the context of the union type.
+    # @return [Object] The context of the union type.
+    def get_context
+      @union_type_context
+    end
+  end
+end

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -33,6 +33,15 @@ module CoreLibrary
           to be implemented in a child class.'
     end
 
+    # Serializes a given value.
+    # @param value [Object] The value to be serialized.
+    # @raise [NotImplementedError] If the method is not implemented in the child class.
+    # @return [String] The serialized representation of the value.
+    def serialize(value)
+      raise NotImplementedError, 'This method needs
+          to be implemented in a child class.'
+    end
+
     # Deserializes a value based on the union type.
     # This method should be implemented by subclasses.
     # @param value [Object] The value to deserialize.

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -12,8 +12,7 @@ module CoreLibrary
     # This constant is used within the UnionType class to define the allowed native types.
     NATIVE_TYPES = [Integer, String, Float, TrueClass, FalseClass].freeze
 
-    attr_accessor :is_valid, :error_messages
-    attr_reader :union_type_context, :union_types
+    attr_accessor :is_valid, :error_messages, :union_type_context, :union_types
 
     # Initializes a new instance of UnionType.
     # @param union_types [Array<Class>] An array of allowed types for the union.

--- a/lib/apimatic-core-interfaces/types/union_type.rb
+++ b/lib/apimatic-core-interfaces/types/union_type.rb
@@ -1,5 +1,4 @@
 module CoreLibrary
-
   # Represents a union type that can validate and deserialize values based on a set of allowed types.
   class UnionType
     # NATIVE_TYPES represents the list of native types in Ruby.

--- a/lib/apimatic_core_interfaces.rb
+++ b/lib/apimatic_core_interfaces.rb
@@ -4,6 +4,7 @@ require_relative 'apimatic-core-interfaces/client/client_configuration'
 require_relative 'apimatic-core-interfaces/factories/response_factory'
 
 require_relative 'apimatic-core-interfaces/types/authentication'
+require_relative 'apimatic-core-interfaces/types/union_type'
 require_relative 'apimatic-core-interfaces/types/http_callback'
 require_relative 'apimatic-core-interfaces/types/http_method'
 require_relative 'apimatic-core-interfaces/types/array_serialization_format'


### PR DESCRIPTION
This PR supports union types that are OneOf and AnyOf types by providing the base type by the name of the UnionType which is an abstract class. The concrete implementation of this class is OneOf, AnyOf, and LeafType classes which are part of the core library.

closes #9